### PR TITLE
Namespace filter , ProjectId attribute support, Manage Package Installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ OPTIONS
                                                    1:MyPackage1Key 2: 3:MyPackage3Key... to allow some packages without
                                                    installation key)
 
+  -n, --namespaces=namespaces                      filter package installation by namespace
+
   -r, --noprompt                                   allow Remote Site Settings and Content Security Policy websites to
                                                    send or receive data without confirmation
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ EXAMPLE
   $ texei:package:dependencies:install -u MyScratchOrg -v MyDevHub -k "1:MyPackage1Key 2: 3:MyPackage3Key" -b "DEV"
 ```
 
-_See code: [src/commands/texei/package/dependencies/install.ts](https://github.com/texei/texei-sfdx-plugin/blob/v0.0.2/src/commands/texei/package/dependencies/install.ts)_
+_See code: [src/commands/texei/package/dependencies/install.ts](https://github.com/texei/texei-sfdx-plugin/blob/v0.0.3/src/commands/texei/package/dependencies/install.ts)_
 
 ## `sfdx texei:user:update`
 
@@ -81,5 +81,5 @@ EXAMPLES
   $ sfdx texei:user:update  --values "UserPermissionsKnowledgeUser=true --json"
 ```
 
-_See code: [src/commands/texei/user/update.ts](https://github.com/texei/texei-sfdx-plugin/blob/v0.0.2/src/commands/texei/user/update.ts)_
+_See code: [src/commands/texei/user/update.ts](https://github.com/texei/texei-sfdx-plugin/blob/v0.0.3/src/commands/texei/user/update.ts)_
 <!-- commandsstop -->

--- a/package.json
+++ b/package.json
@@ -9,8 +9,10 @@
     "@oclif/config": "1",
     "@oclif/errors": "1",
     "@salesforce/command": "0.1.5",
+    "@types/underscore": "^1.8.9",
     "child-process-promise": "^2.2.1",
-    "child_process": "^1.0.2"
+    "child_process": "^1.0.2",
+    "underscore": "^1.9.1"
   },
   "devDependencies": {
     "@oclif/dev-cli": "1",

--- a/src/commands/texei/package/dependencies/install.ts
+++ b/src/commands/texei/package/dependencies/install.ts
@@ -41,7 +41,7 @@ export default class Install extends SfdxCommand {
 
   public async run(): Promise<any> {
 
-    const result = { installedPackages: [] };
+    const result = { installedPackages: {} };
 
     // this.org is guaranteed because requiresUsername=true, as opposed to supportsUsername
     const username = this.org.getUsername();
@@ -171,6 +171,8 @@ export default class Install extends SfdxCommand {
   }
 
   private async getPackageVersionId(name, version) {
+
+    this.ux.log(`getPackageVersionId() name ${name} version ${version}`);
 
     let packageId = messages.getMessage('invalidPackageName');
     // Keeping original name so that it can be used in error message if needed

--- a/src/commands/texei/package/dependencies/install.ts
+++ b/src/commands/texei/package/dependencies/install.ts
@@ -82,7 +82,7 @@ export default class Install extends SfdxCommand {
           const dependencyInfo = dependency as core.JsonMap;
           const dependentPackage: string = ((dependencyInfo.packageId != null) ? dependencyInfo.packageId : dependencyInfo.package) as string;
           const versionNumber: string = (dependencyInfo.versionNumber) as string;
-          const namespaces: string[] = this.flags.namespaces.split(',');
+          const namespaces: string[] = this.flags.namespaces !== undefined ? this.flags.namespaces.split(',') : null;
 
           if (dependentPackage == null) {
             throw Error('Dependent package version unknow error.');
@@ -202,6 +202,7 @@ export default class Install extends SfdxCommand {
       let query = 'Select SubscriberPackageVersionId, IsPasswordProtected, IsReleased, Package2.NamespacePrefix ';
       query += 'from Package2Version ';
       query += `where Package2Id='${packageName}' and MajorVersion=${vers[0]} and MinorVersion=${vers[1]} and PatchVersion=${vers[2]} `;
+
       if (namespaces != null) {
         query += ` and Package2.NamespacePrefix IN ('${namespaces.join('\',\'')}')`;
       }

--- a/src/commands/texei/package/dependencies/install.ts
+++ b/src/commands/texei/package/dependencies/install.ts
@@ -123,6 +123,10 @@ export default class Install extends SfdxCommand {
       let i = 0;
       for (let packageInfo of packagesToInstall) {
         packageInfo = packageInfo as core.JsonMap;
+        if (result.installedPackages.hasOwnProperty(packageInfo.packageVersionId)) {
+          this.ux.log(`PackageVersionId ${packageInfo.packageVersionId} already installed. Skipping...`);
+          continue;
+        }
 
         // Split arguments to use spawn
         const args = [];
@@ -161,7 +165,7 @@ export default class Install extends SfdxCommand {
 
         this.ux.log('\n');
 
-        result.installedPackages[i] = packageInfo;
+        result.installedPackages[packageInfo.packageVersionId] = packageInfo;
 
         i++;
       }
@@ -171,8 +175,6 @@ export default class Install extends SfdxCommand {
   }
 
   private async getPackageVersionId(name, version) {
-
-    this.ux.log(`getPackageVersionId() name ${name} version ${version}`);
 
     let packageId = messages.getMessage('invalidPackageName');
     // Keeping original name so that it can be used in error message if needed

--- a/yarn.lock
+++ b/yarn.lock
@@ -248,6 +248,10 @@
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-5.0.1.tgz#a15b36ec42f1f53166617491feabd1734cb03e21"
 
+"@types/underscore@^1.8.9":
+  version "1.8.9"
+  resolved "https://registry.yarnpkg.com/@types/underscore/-/underscore-1.8.9.tgz#fef41f800cd23db1b4f262ddefe49cd952d82323"
+
 ajv@^5.1.0:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
@@ -2354,6 +2358,10 @@ type-detect@^4.0.0, type-detect@^4.0.8:
 typescript@2.8:
   version "2.8.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.4.tgz#0b1db68e6bdfb0b767fa2ab642136a35b059b199"
+
+underscore@^1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.9.1.tgz#06dce34a0e68a7babc29b365b8e74b8925203961"
 
 union-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
- I a project sometimes is not interesting to install some namespaces package. Now using the flag ```-- namespaces ns1,ns2``` we can do it;
- Now it works using package or PackageId attributes