### PR TITLE
fix package filter

### DIFF
--- a/src/commands/texei/package/dependencies/install.ts
+++ b/src/commands/texei/package/dependencies/install.ts
@@ -76,6 +76,9 @@ export default class Install extends SfdxCommand {
       }
     }
 
+    //see if no filter is true
+    const packagesNoFilter = (this.flags.packages == null);;
+
     this.ux.startSpinner('Resolving dependencies');
 
     for (let packageDirectory of packageDirectories) {
@@ -83,7 +86,7 @@ export default class Install extends SfdxCommand {
       const packageName = (packageDirectory.package && packageDirectory.package.toString()) ? packageDirectory.package.toString() : '';
 
       // If the package is found, or if there isn't any package filtering
-      if (packages.has(packageName) || packages.size == 0) {
+      if (packages.has(packageName) || packagesNoFilter) {
 
         const dependencies = packageDirectory.dependencies || [];
 


### PR DESCRIPTION
if package filter was specified and once it was removed from the set, all remaining packages are added as if no filter.