### PR TITLE
Added option to sort exported data and allow upserting data on import

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Link the plugin: sfdx plugins:link .
 <!-- commands -->
 * [`sfdx texei:contractstatus:value:add -l <string> -a <string> [-s <string>] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-texeicontractstatusvalueadd--l-string--a-string--s-string--u-string---apiversion-string---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
 * [`sfdx texei:data:export -d <string> [-o <string>] [-p <string>] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-texeidataexport--d-string--o-string--p-string--u-string---apiversion-string---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
-* [`sfdx texei:data:import -d <string> [-a] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-texeidataimport--d-string--a--u-string---apiversion-string---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
+* [`sfdx texei:data:import -d <string> [-a] [-p <string>] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-texeidataimport--d-string--a--p-string--u-string---apiversion-string---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
 * [`sfdx texei:data:plan:generate -d <string> -o <string> [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-texeidataplangenerate--d-string--o-string---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
 * [`sfdx texei:org:contractfieldhistory:fix [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-texeiorgcontractfieldhistoryfix--u-string---apiversion-string---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
 * [`sfdx texei:org:shape:extract [-d <string>] [-s <string>] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-texeiorgshapeextract--d-string--s-string--u-string---apiversion-string---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
@@ -110,13 +110,13 @@ EXAMPLES
 
 _See code: [src/commands/texei/data/export.ts](https://github.com/texei/texei-sfdx-plugin/blob/v1.11.1/src/commands/texei/data/export.ts)_
 
-## `sfdx texei:data:import -d <string> [-a] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
+## `sfdx texei:data:import -d <string> [-a] [-p <string>] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
 import objects' data to org
 
 ```
 USAGE
-  $ sfdx texei:data:import -d <string> [-a] [-u <string>] [--apiversion <string>] [--json] [--loglevel 
+  $ sfdx texei:data:import -d <string> [-a] [-p <string>] [-u <string>] [--apiversion <string>] [--json] [--loglevel 
   trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]
 
 OPTIONS
@@ -126,6 +126,8 @@ OPTIONS
 
   -d, --inputdir=inputdir                                                           (required) directory with files to
                                                                                     import
+
+  -p, --dataplan=dataplan                                                           path to data plan file
 
   -u, --targetusername=targetusername                                               username or alias for the target
                                                                                     org; overrides default target org

--- a/messages/data-import.json
+++ b/messages/data-import.json
@@ -1,5 +1,6 @@
 {
     "commandDescription": "import objects' data to org",
     "inputFlagDescription": "directory with files to import",
-    "allOrNoneFlagDescription": "any failed records in a call cause all changes for the call to be rolled back"
+    "allOrNoneFlagDescription": "any failed records in a call cause all changes for the call to be rolled back",
+    "dataPlanFlagDescription": "path to data plan file"
 }

--- a/src/commands/texei/data/DataPlan.d.ts
+++ b/src/commands/texei/data/DataPlan.d.ts
@@ -7,5 +7,6 @@ interface DataPlanSObject {
     name: string;
     label: string;
     filters: string;
+    orderBy: string;
     excludedFields: Array<string>;
 }

--- a/src/commands/texei/data/DataPlan.d.ts
+++ b/src/commands/texei/data/DataPlan.d.ts
@@ -8,5 +8,6 @@ interface DataPlanSObject {
     label: string;
     filters: string;
     orderBy: string;
+    externalId: string;
     excludedFields: Array<string>;
 }

--- a/src/commands/texei/data/DataPlan.d.ts
+++ b/src/commands/texei/data/DataPlan.d.ts
@@ -1,0 +1,11 @@
+interface DataPlan {
+    excludedFields: Array<string>;
+    sObjects: Array<DataPlanSObject>;
+}
+
+interface DataPlanSObject {
+    name: string;
+    label: string;
+    filters: string;
+    excludedFields: Array<string>;
+}

--- a/src/commands/texei/data/export.ts
+++ b/src/commands/texei/data/export.ts
@@ -147,7 +147,8 @@ export default class Export extends SfdxCommand {
     // Query to get sObject data
     const recordQuery = `SELECT Id, ${fields.join()}
                          FROM ${sobject.name}
-                         ${sobject.filters ? 'WHERE '+sobject.filters : ''}`;
+                         ${sobject.filters ? 'WHERE '+sobject.filters : ''}
+                         ${sobject.orderBy ? 'ORDER BY '+sobject.orderBy : ''}`;
     // API Default limit is 10 000, just check if we need to extend it
     const recordNumber:number = ((await conn.query(`Select count(Id) numberOfRecords from ${sobject.name}`)).records[0] as any).numberOfRecords;
     let options:ExecuteOptions = {};

--- a/src/commands/texei/data/export.ts
+++ b/src/commands/texei/data/export.ts
@@ -6,13 +6,6 @@ import * as fs from 'fs';
 import * as path from 'path';
 const util = require("util");
 
-interface DataPlan {
-  name: string;
-  label: string;
-  filters: string;
-  excludedFields: Array<string>;
-}
-
 // Initialize Messages with the current plugin directory
 Messages.importMessagesDirectory(__dirname);
 
@@ -20,7 +13,7 @@ Messages.importMessagesDirectory(__dirname);
 // or any library that is using the messages framework can also be loaded this way.
 const messages = Messages.loadMessages('texei-sfdx-plugin', 'data-export');
 let conn:Connection;
-let objectList:Array<DataPlan>;
+let objectList:Array<DataPlanSObject>;
 let lastReferenceIds: Map<string, number> = new Map<string, number>();
 let globallyExcludedFields: Array<string>;
 
@@ -67,7 +60,7 @@ export default class Export extends SfdxCommand {
     else if (this.flags.dataplan) {
       // Read objects list from file
       const readFile = util.promisify(fs.readFile);
-      const dataPlan = JSON.parse(await readFile(this.flags.dataplan, "utf8"));
+      const dataPlan: DataPlan = JSON.parse(await readFile(this.flags.dataplan, "utf8"));
       objectList = dataPlan.sObjects;
 
       // If there are some globally excluded fields, add them
@@ -96,7 +89,7 @@ export default class Export extends SfdxCommand {
     return { message: 'Data exported' };
   }
 
-  private async getsObjectRecords(sobject: DataPlan, recordIdsMap: Map<string, string>) {
+  private async getsObjectRecords(sobject: DataPlanSObject, recordIdsMap: Map<string, string>) {
 
     // Query to retrieve creatable sObject fields
     let fields = [];
@@ -171,7 +164,7 @@ export default class Export extends SfdxCommand {
 
   // Clean JSON to have the same output format as force:data:tree:export
   // Main difference: RecordTypeId is replaced by DeveloperName
-  private async cleanJsonRecord(sobject: DataPlan, objectLabel: string, records, recordIdsMap, lookups: Array<string>, userFieldsReference: Array<string>,) {
+  private async cleanJsonRecord(sobject: DataPlanSObject, objectLabel: string, records, recordIdsMap, lookups: Array<string>, userFieldsReference: Array<string>,) {
 
     let refId = 0;
     // If this object was already exported before, start the numbering after the last one already used

--- a/src/commands/texei/data/plan/generate.ts
+++ b/src/commands/texei/data/plan/generate.ts
@@ -48,6 +48,7 @@ export default class Generate extends SfdxCommand {
           name: objectName,
           label: "",
           filters: "",
+          orderBy: "",
           excludedFields: []
       });
     }

--- a/src/commands/texei/data/plan/generate.ts
+++ b/src/commands/texei/data/plan/generate.ts
@@ -49,6 +49,7 @@ export default class Generate extends SfdxCommand {
           label: "",
           filters: "",
           orderBy: "",
+          externalId: "",
           excludedFields: []
       });
     }

--- a/src/commands/texei/data/plan/generate.ts
+++ b/src/commands/texei/data/plan/generate.ts
@@ -37,19 +37,19 @@ export default class Generate extends SfdxCommand {
 
   public async run(): Promise<AnyJson> {
 
-    let dataPlan = { 
-      "excludedFields": [], 
-      "sObjects": [] 
+    let dataPlan: DataPlan = {
+      excludedFields: [],
+      sObjects: []
     };
 
     // Read objects list from flag, mapping to data plan format
     for (const objectName of this.flags.objects.split(',')) {
-        dataPlan.sObjects.push({
-            "name": objectName,
-            "label": "",
-            "filters": "",
-            "excludedFields": []
-        });
+      dataPlan.sObjects.push({
+          name: objectName,
+          label: "",
+          filters: "",
+          excludedFields: []
+      });
     }
 
     // Save file


### PR DESCRIPTION
Hi,

we are using your great plugin to export/import CPQ related records and keep them under version control.

We noticed that the order of the exported records are not always the same so git picked up more changes than were actually made.
In this PR I have added an option to the `data-plan.json` file to optionally specify an orderBy clause for the SOQL query so that the exported records always stay in the same order.

Additionally we were facing the issue of updating existing records in a scratch org (or even in production) with the latest data under version control.
In this PR I have added an option to the `data-plan.json` file to optionally specify an external id so that the exported records can be identified across orgs and therefore be upserted.
For records we create manually we are using a simple number field and set the default value to an unix time stamp using the following formula: `(NOW() - DATETIMEVALUE("1970-01-01 00:00:00")) * 86400`. 
This works great as long as you do not bulk insert records. But any kind of unique value should work.

Regards,
André

