### PR TITLE
Adding Export Owner functionality

### DIFF
--- a/src/commands/texei/data/plan/generate.ts
+++ b/src/commands/texei/data/plan/generate.ts
@@ -48,7 +48,8 @@ export default class Generate extends SfdxCommand {
             "name": objectName,
             "label": "",
             "filters": "",
-            "excludedFields": []
+            "excludedFields": [],
+            "exportOwner": false
         });
     }
 


### PR DESCRIPTION
Hi,

I was using your plugin to copy data between orgs and needed the OwnerId to be retained. I believe this is enhancement request #73 

I have made a change so that in the data-plan.json there is an optional parameter “exportOwner”, which if set to true will include the Owner Id in the generated JSON. In the import routine, it will attempt to link the original Owner if it exists in the org.

Thanks for this plugin btw. It’s really great!

Kind regards,

Mark