### PR TITLE
support upserting more than 10 records

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "texei-sfdx-plugin",
   "description": "Texeï's plugin for sfdx",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "author": "Texeï",
   "bugs": "https://github.com/https://github.com/texei/texei-sfdx-plugin/issues",
   "dependencies": {


### PR DESCRIPTION
This is a fix (or more a workaround) to my last PR adding support to upsert data.
Right now the upsert works perfectly if there are less than (or equals) 10 records.

The underlying issue is that `jsforce` currently does not support upsert using the collection api as it does with insert and update ([1156](https://github.com/jsforce/jsforce/issues/1156), [1194](https://github.com/jsforce/jsforce/issues/1194)). As stated in the referenced issues this *may* be included in version 2.0.

To get around this in the meantime, I have added a loop to process the upsert records in chunks of 10.
Per default `10` is the max. parallel request count as specified [here](https://github.com/jsforce/jsforce/blob/82fcc5284215e95047d0f735dd3037a1aeba5d88/lib/connection.js#L82).

