### PR TITLE
encode external id field

### DIFF
--- a/src/commands/texei/data/import.ts
+++ b/src/commands/texei/data/import.ts
@@ -308,6 +308,9 @@ export default class Import extends SfdxCommand {
       // external id field is specified --> upsert
       this.debug(`DEBUG upserting ${sobjectName} records using external id field '${externalIdField}'`);
 
+      records.forEach(record => {
+        record[externalIdField] = encodeURI(record[externalIdField]);
+      });
       // max. parallel upsert requests as supported by jsforce (default)
       // https://github.com/jsforce/jsforce/blob/82fcc5284215e95047d0f735dd3037a1aeba5d88/lib/connection.js#L82
       const maxParallelUpsertRequests = batchSizeMap.get(dataFileName) ? batchSizeMap.get(dataFileName) : 10;


### PR DESCRIPTION
Adding URL encoding to the external ID used in a REST upsert call, as this can include "/" which will interpret as additional path without being encoded.

There is already a pull request in jsforce, but it is not merged sinced a year.
https://github.com/jsforce/jsforce/pull/1258