### PR TITLE
Updated logic to select input/select elements for updating CPQ Settings

### DIFF
--- a/src/commands/texei/cpqsettings/set.ts
+++ b/src/commands/texei/cpqsettings/set.ts
@@ -113,8 +113,7 @@ export default class Set extends SfCommand<CpqSettingsSetResult> {
           targetType = 'select';
         }
 
-        const isInputDisabled =
-          ((await (await targetInput?.getProperty('disabled'))?.jsonValue()) as string) !== 'disabled';
+        const isInputDisabled = (await (await targetInput?.getProperty('disabled'))?.jsonValue()) as boolean;
 
         let currentValue = '';
         if (targetType === 'checkbox') {

--- a/src/commands/texei/cpqsettings/set.ts
+++ b/src/commands/texei/cpqsettings/set.ts
@@ -64,12 +64,15 @@ export default class Set extends SfCommand<CpqSettingsSetResult> {
       headless: !(process.env.BROWSER_DEBUG === 'true') ? 'new' : false,
     });
     const page = await browser.newPage();
+
+    this.log(`Logging in to instance ${instanceUrl}`);
     await page.goto(
       `${instanceUrl}/secur/frontdoor.jsp?sid=${flags['target-org'].getConnection(flags['api-version']).accessToken}`,
       { waitUntil: ['domcontentloaded', 'networkidle0'] }
     );
     const navigationPromise = page.waitForNavigation();
 
+    this.log(`Navigating to CPQ Settings Page ${cpqSettingsUrl}`);
     await page.goto(`${cpqSettingsUrl}`);
     await navigationPromise;
 
@@ -132,9 +135,9 @@ export default class Set extends SfCommand<CpqSettingsSetResult> {
             await targetInput?.click();
             await navigationPromise;
 
-            this.spinner.stop(`Value updated from ${currentValue} to ${cpqSettings[tabKey][key]}`);
+            this.spinner.stop(`Checkbox Value updated from ${currentValue} to ${cpqSettings[tabKey][key]}`);
           } else {
-            this.spinner.stop('Value already ok');
+            this.spinner.stop('Checkbox Value already ok');
           }
         } else if (targetType === 'text') {
           currentValue = await (await targetInput?.getProperty('value'))?.jsonValue();
@@ -145,9 +148,9 @@ export default class Set extends SfCommand<CpqSettingsSetResult> {
             await targetInput?.type(`${cpqSettings[tabKey][key]}`);
             await page.keyboard.press('Tab');
 
-            this.spinner.stop(`Value updated from ${currentValue} to ${cpqSettings[tabKey][key]}`);
+            this.spinner.stop(`Text Value updated from ${currentValue} to ${cpqSettings[tabKey][key]}`);
           } else {
-            this.spinner.stop('Value already ok');
+            this.spinner.stop('Text Value already ok');
           }
         } else if (targetType === 'select') {
           await page.waitForXPath(`//select[@name="${attributeId}"]/option[text()='${cpqSettings[tabKey][key]}']`);
@@ -171,9 +174,9 @@ export default class Set extends SfCommand<CpqSettingsSetResult> {
               optionElement.selected = true;
             }, optionElement);
 
-            this.spinner.stop(`Value updated from ${currentValue} to ${cpqSettings[tabKey][key]}`);
+            this.spinner.stop(`Picklist Value updated from ${currentValue} to ${cpqSettings[tabKey][key]}`);
           } else {
-            this.spinner.stop('Value already ok');
+            this.spinner.stop('Picklist Value already ok');
           }
         }
 

--- a/src/commands/texei/cpqsettings/set.ts
+++ b/src/commands/texei/cpqsettings/set.ts
@@ -18,6 +18,7 @@ import {
 } from '@salesforce/sf-plugins-core';
 import { Messages, SfError } from '@salesforce/core';
 import * as puppeteer from 'puppeteer';
+import { ElementHandle } from 'puppeteer';
 
 // Initialize Messages with the current plugin directory
 Messages.importMessagesDirectory(__dirname);
@@ -84,9 +85,11 @@ export default class Set extends SfCommand<CpqSettingsSetResult> {
 
       // Getting id for label
       const tabs = await page.$x(`//td[contains(text(), '${tabKey}')]`);
+      if (tabs.length !== 1) this.error(`Tab ${tabKey} not found!`);
 
       // Clicking on tab
-      await tabs[0].click();
+      const tab = tabs[0].asElement() as ElementHandle<Element>;
+      await tab.click();
       await navigationPromise;
 
       // For all fields on tab

--- a/src/commands/texei/cpqsettings/set.ts
+++ b/src/commands/texei/cpqsettings/set.ts
@@ -61,7 +61,7 @@ export default class Set extends SfCommand<CpqSettingsSetResult> {
     // Init browser
     const browser = await puppeteer.launch({
       args: ['--no-sandbox', '--disable-setuid-sandbox'],
-      headless: !(process.env.BROWSER_DEBUG === 'true'),
+      headless: !(process.env.BROWSER_DEBUG === 'true') ? 'new' : false,
     });
     const page = await browser.newPage();
     await page.goto(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
     "outDir": "lib",
     "rootDir": "src",
     "strictNullChecks": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "lib": ["dom"]
   },
   "include": ["./src/**/*.ts"]
 }


### PR DESCRIPTION
Fixes #145

This PR updates the logic to select the correct `input`/`select` element for the specified label to support config options without an help text (e.g. "Enable Evergreen Subscriptions").

This PR uses the following logic to select the correct input:
1. Find the label containing the specified label text
2. Traverse to the ancestor `th` element with class `labelCol`
3. Go to the first sibling `td` element with class `dataCol` or `data2Col`
4. Select the first child `input` or `select` element

The selection of the current and target picklist values uses the following logic:
1. Current value: Get the `value` property of the input and select the option by using this property.
2. Target value: Get the option element by using the display value and then get the `value` property of the element. Afterwards the input is updated by using the `select()` method and specifying the target value.


Additionally, I have added a check to look for options which cannot be updated (disabled controls). If the target value does not match the existing value an error is logged.
This is necessary because you cannot deactivate the "Enable Evergreen Subscriptions" checkbox after it is enabled. Maybe this applies to other controls as well. Therefore I have added this check for all controls.

