### PR TITLE
Fix: Keep description tag in profiles during "texei profile clean" command

### DIFF
--- a/src/commands/texei/profile/clean.ts
+++ b/src/commands/texei/profile/clean.ts
@@ -48,7 +48,7 @@ export default class Clean extends SfCommand<ProfileCleanResult> {
     const cleanResult: string[] = [];
 
     // TODO: Keep default recordTypeVisibilities & applicationVisibilities like in skinnyprofile:retrieve
-    const defaultKeep = ['layoutAssignments', 'loginHours', 'loginIpRanges', 'custom', 'userLicense'];
+    const defaultKeep = ['layoutAssignments', 'loginHours', 'loginIpRanges', 'custom', 'userLicense', 'description'];
     const nodesToKeep = flags.keep ? flags.keep : defaultKeep;
     let profilesToClean: string[] = [];
 


### PR DESCRIPTION
This pull request addresses an issue where the description tag is removed from user profiles when executing the "texei profile clean" command.