### PR TITLE
Installation-Keys as dict and slice on key

### DIFF
--- a/src/commands/texei/package/dependencies/install.ts
+++ b/src/commands/texei/package/dependencies/install.ts
@@ -199,26 +199,32 @@ export default class Install extends SfCommand<PackageDependenciesInstallResult>
 
       // Getting Installation Key(s)
       let installationKeysString: string = flags.installationkeys as string;
-      let installationKeys: string[] = [];
+      let installationKeys = {};
       if (installationKeysString) {
         installationKeysString = installationKeysString.trim();
-        installationKeys = installationKeysString.split(' ');
-
+        let installationKeysSplit = installationKeysString.split(' ');
+      
         // Format is 1: 2: 3: ... need to remove these
-        for (let keyIndex = 0; keyIndex < installationKeys.length; keyIndex++) {
-          const key = installationKeys[keyIndex].trim();
-          if (key.startsWith(`${keyIndex + 1}:`)) {
-            installationKeys[keyIndex] = key.substring(keyIndex.toString().length + 1);
-          } else {
+        for (let installationKey of installationKeysSplit) {
+          const key = installationKey.slice(0, installationKey.indexOf(':'));
+          const password = installationKey.slice(installationKey.indexOf(':') + 1);
+      
+          if (!key) {
             // Format is not correct, throw an error
             throw new SfError('Installation Key should have this format: 1:MyPackage1Key 2: 3:MyPackage3Key');
           }
+          if (installationKeys[key]) {
+            // Don't assume last overrides
+            throw new SfError("key already exists: " + key);
+          } else {
+            // Keys don't have to be in a specific order and packages without keys don't require it specifed
+            installationKeys[key] = password;
+          }
         }
       }
-
       this.log('\n');
 
-      let i = 0;
+      let i = 1;
       for (let packageInfo of packagesToInstall) {
         // @ts-ignore: TODO: working code, but look at TS warning
         packageInfo = packageInfo as JsonMap;


### PR DESCRIPTION
Issue:
The zero based indexing wasn't handling the 10th key correctly.

A dict allows for the keys to be in any order, or not specified at all.

Note:
There is still an issue, where installationKeys doesn't take into account, the reduced list of packagesToInstall.