### PR TITLE
fix: Winter 25 - Legacy redirections disabled, CPQ set settings

### DIFF
--- a/src/commands/texei/cpqsettings/set.ts
+++ b/src/commands/texei/cpqsettings/set.ts
@@ -224,8 +224,19 @@ export default class Set extends SfCommand<CpqSettingsSetResult> {
     return `${instanceUrlClean}/secur/frontdoor.jsp?sid=${accessToken}`;
   }
 
-  // eslint-disable-next-line class-methods-use-this
-  private async getSettingURL(urlOfInstance: string) {
-    return `${urlOfInstance.substring(0, urlOfInstance.indexOf('.'))}--sbqq.visualforce.com/apex/EditSettings`;
+  private async getSettingURL(urlOfInstance: string): Promise<string> {
+    let prefix;
+
+    if (this.org.isScratch()) {
+      prefix = "--sbqq.scratch";
+    } else if (this.org.isSandbox()) {
+      prefix = "--sbqq.sandbox";
+    } else {
+      prefix = "--sbqq";
+    }
+  
+    const ending = `${prefix}.vf.force.com/apex/EditSettings`
+    
+    return `${urlOfInstance.substring(0, urlOfInstance.indexOf('.'))}${ending}`;
   }
 }


### PR DESCRIPTION
Winter 25 - Legacy redirections disabled
https://help.salesforce.com/s/articleView?id=sf.domain_name_enhanced_timeline.htm&type=5

<img width="1405" alt="image" src="https://github.com/user-attachments/assets/241f3918-a238-4f20-807e-b74580364b85">
